### PR TITLE
📄 Make package.json licence match the repository licence

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
   "engines": {
     "node": ">=14.x.x"
   },
-  "license": "MIT"
+  "license": "GPL-3.0-only"
 }


### PR DESCRIPTION
In accordance to https://spdx.org/licenses/ and https://spdx.org/licenses/GPL-3.0-only.html